### PR TITLE
fix: code: 40001 invalid credential, access_token is invalid or not l…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,11 @@ export default class WechatOAuth {
   public async getUserByCode(code: string, lang = 'en') {
     const accessToken = await this.getAccessToken(code)
     const openId = accessToken.openid
-    return await this.getUserByOpenId(openId, lang)
+    try {
+        return await this.getUserByOpenId(openId, lang);
+    } catch (error) {
+      return await this.getUserByOpenIdAndAccessToken(openId, accessToken.access_token, lang);
+    }
   }
 
   public async getQRCodeTicket(


### PR DESCRIPTION
最近测试，获取`access_token`后，保存在数据库中的`access_token`用来获取用户信息时常出错，报：40001，invalid credential, access_token is invalid or not latest。我通过用最新的`access_token`，再次调用`this.getUserByOpenIdAndAccessToken(openId, accessToken.access_token, lang);`可以解决。这样写，我感觉代码会更健壮点，失败也能获取到用户信息。